### PR TITLE
do not add file to add to asset in release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/currentscape-${{ env.TAG_NAME }}.tar.gz
           tag_name: ${{ env.TAG_NAME }}
           name: ${{ env.TAG_NAME }}
           generate_release_notes: true


### PR DESCRIPTION
... because code and tar are already present. Adding another tar file is not necessary. See https://github.com/BlueBrain/Currentscape/releases/tag/1.0.7