### PR TITLE
can now use currentscape.plot instead of plot_currentscape

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ When you then execute the following python code, a window should open with the c
     import numpy as np
     from neuron import h
     from neuron.units import ms, mV
-    from currentscape.currentscape import plot_currentscape
+    import currentscape
 
 
     def main():
@@ -142,7 +142,7 @@ When you then execute the following python code, a window should open with the c
             }
         }
 
-        fig = plot_currentscape(voltage, [potassium, sodium, leak], config)
+        fig = currentscape.plot(voltage, [potassium, sodium, leak], config)
         fig.show()
 
 

--- a/Tutorial.rst
+++ b/Tutorial.rst
@@ -214,7 +214,7 @@ Showing x axis label, ticklabel, gridlines
 
 You can use the configuration to show x axis label, ticklabels and vertical gridlines. 
 If you choose to display them, the label and ticklabels will only show on the bottom plot, and the vertical gridlines will show on all plots, and correspond to the x ticks (generated automatically, if not set in the config). 
-However, to show ticklabels and gridlines, you have to also input time as an argument to the plot_currentscape function. Here is an example:
+However, to show ticklabels and gridlines, you have to also input time as an argument to the :code:`currentscape.plot` function. Here is an example:
 
 .. code-block:: python
 
@@ -228,7 +228,7 @@ However, to show ticklabels and gridlines, you have to also input time as an arg
     config = "path/to/config.json"
 
     # produce Currentscape figure
-    fig = plot_currentscape(voltage, currents, config, time=time)
+    fig = currentscape.plot(voltage, currents, config, time=time)
 
 Be aware that the time data are expected to grow monotonically.
 
@@ -267,7 +267,7 @@ However, these methods can be useful to display the main features of the plots, 
 Showing ionic concentrations
 ============================
 
-You can plot the ionic concentrations in a subplot at the bottom of the figure by passing your ionic concentration data to the main function: :code:`plot_currentscape(voltage, currents, config, ions)`, and by passing the ion names to the config under: :code:`"ions":{"names":your_list}`. Note that, as for the currents, the ion names should correspond to the ion data (i.e. be listed in the same order).
+You can plot the ionic concentrations in a subplot at the bottom of the figure by passing your ionic concentration data to the main function: :code:`currentscape.plot(voltage, currents, config, ions)`, and by passing the ion names to the config under: :code:`"ions":{"names":your_list}`. Note that, as for the currents, the ion names should correspond to the ion data (i.e. be listed in the same order).
 
 Showing overall contribution pie charts
 =======================================

--- a/currentscape/__init__.py
+++ b/currentscape/__init__.py
@@ -13,3 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from currentscape.currentscape import plot_currentscape as plot

--- a/examples/original_paper_plot/integrate_single_compartment_and_plot_currentscape.py
+++ b/examples/original_paper_plot/integrate_single_compartment_and_plot_currentscape.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.integrate import odeint
 from single_compartment import single_compartment
 from get_currents import model
-from currentscape.currentscape import plot_currentscape
+import currentscape
 
 
 def plot_from_original_paper(t0=0.0, tf=10000.0, dt=0.1):
@@ -54,7 +54,7 @@ def plot_from_original_paper(t0=0.0, tf=10000.0, dt=0.1):
     currents = model(fullsolution, parameters, temp)
 
     # plot currentscape (full temporal range)
-    fig = plot_currentscape(voltage, currents, config)
+    fig = currentscape.plot(voltage, currents, config)
 
 
 if __name__ == "__main__":

--- a/examples/use_case/plot.py
+++ b/examples/use_case/plot.py
@@ -17,7 +17,7 @@
 from pathlib import Path
 import numpy as np
 
-from currentscape.currentscape import plot_currentscape
+import currentscape
 
 from run import absolute_path
 
@@ -68,7 +68,7 @@ def plot():
 
 
     # produce currentscape figure
-    fig = plot_currentscape(voltage, currents, config, ions)
+    fig = currentscape.plot(voltage, currents, config, ions)
     return fig
 
 if __name__ == "__main__":


### PR DESCRIPTION
-can still use legacy from currentscape.currentscape import plot_currentscape
-modified readme, tutorial, examples accordingly
-solves issue #33 