### PR TITLE
remove BBP copyright in Readme, as was done in PR #7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,6 @@ We wish to thank the authors of `Alonso and Marder, 2019 <https://doi.org/10.755
 
 The part of the code in this repository developed by the EPFL Blue Brain Project was supported by funding to the Blue Brain Project, a research center of the École polytechnique fédérale de Lausanne (EPFL), from the Swiss government's ETH Board of the Swiss Federal Institutes of Technology.
 
-Copyright (c) 2023-2024 Blue Brain Project/EPFL
 
 .. |pypi| image:: https://img.shields.io/pypi/v/currentscape.svg
                :target: https://pypi.org/project/currentscape/


### PR DESCRIPTION
As was said in comments of PR #46 : I don't think we were supposed to add a copyright: it was purposefully removed by Werner in the PR https://github.com/BlueBrain/Currentscape/pull/7 because this is based on code from Alonso and Marder.